### PR TITLE
Implement asYouGo option

### DIFF
--- a/better_benchwarmer.js
+++ b/better_benchwarmer.js
@@ -281,7 +281,20 @@ function main() {
     // Execute the Add function with current settings
     var additions = context.getAllObjects("footpath_addition");
     var settings = new Settings(additions);
-    Add(settings);
+    var running = false;
+    function runAdd() {
+        if (running)
+            return;
+        running = true;
+        Add(settings);
+        running = false;
+    }
+    if (settings.asYouGo) {
+        context.subscribe("action.execute", runAdd);
+        runAdd();
+    } else {
+        Add(settings);
+    }
 }
 
 registerPlugin(info, main);


### PR DESCRIPTION
## Summary
- hook the plugin to `action.execute` when the `asYouGo` setting is enabled
- avoid recursive calls when running `Add`

## Testing
- `node --check better_benchwarmer.js`

------
https://chatgpt.com/codex/tasks/task_e_684f4bc9de7483249764a5d59adc7163