### PR TITLE
Fix preserveOtherAdditions setting

### DIFF
--- a/better_benchwarmer.js
+++ b/better_benchwarmer.js
@@ -178,10 +178,10 @@ var Settings = /*#__PURE__*/ function() {
     return Settings;
 }();
 
-function canBuildAdditionOnPath(surface, path) {
+function canBuildAdditionOnPath(surface, path, settings) {
     if (!path || !surface) return false;
     if (surface.isWater) return false;
-    if (path.addition != null && plugin.settings.preserveOtherAdditions) return false;
+    if (path.addition != null && settings.preserveOtherAdditions) return false;
     return true;
 }
 
@@ -215,7 +215,7 @@ function Add(settings) {
                 return element.type === "footpath";
             });
             footpaths.forEach(function(path) {
-                if (canBuildAdditionOnPath(surface, path)) {
+                if (canBuildAdditionOnPath(surface, path, settings)) {
                     if (path.isQueue) {
                         paths.queues.push({ path: path, x: x, y: y2 });
                     } else if ((path === null || path === void 0 ? void 0 : path.slopeDirection) === null) {


### PR DESCRIPTION
## Summary
- allow `canBuildAdditionOnPath` to receive the settings parameter
- use the settings parameter instead of the global `plugin.settings`
- pass `settings` to `canBuildAdditionOnPath` when adding items

## Testing
- `node --check better_benchwarmer.js`

------
https://chatgpt.com/codex/tasks/task_e_684f55a768f48324858d3228564dc9c6