### PR TITLE
Add Better Benchwarmer configuration menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Copy `better_benchwarmer.js` to your OpenRCT2 `plugin` folder and restart the ga
 ## Configuration
 
 When first loaded the plugin asks which bench, bin, lamp and queue TV objects to use. You can also change these selections later from the plugin menu.
+Open the **Better Benchwarmer** entry from the plugin menu to access drop-downs
+for selecting the bench, bin, lamp and queue TV objects. The chosen options are
+stored so they persist between sessions.
 
 Available options include:
 

--- a/better_benchwarmer.js
+++ b/better_benchwarmer.js
@@ -279,6 +279,71 @@ function main() {
     // Execute the Add function with current settings
     var additions = context.getAllObjects("footpath_addition");
     var settings = new Settings(additions);
+    function openMenu() {
+        var window = ui.getWindow("better-benchwarmer.window");
+        if (window) {
+            window.bringToFront();
+            return;
+        }
+
+        var benchItems = settings.benches.map(function (o) { return o.name; });
+        var binItems = settings.bins.map(function (o) { return o.name; });
+        var lampItems = settings.lamps.map(function (o) { return o.name; });
+        var tvItems = settings.queuetvs.map(function (o) { return o.name; });
+
+        ui.openWindow({
+            classification: "better-benchwarmer.window",
+            title: "Better Benchwarmer",
+            width: 200,
+            height: 110,
+            widgets: [
+                { type: "label", x: 10, y: 20, width: 70, height: 12, text: "Bench" },
+                {
+                    type: "dropdown",
+                    x: 80,
+                    y: 15,
+                    width: 110,
+                    height: 12,
+                    items: benchItems,
+                    selectedIndex: settings.selections.bench,
+                    onChange: function(index) { settings.bench = index; }
+                },
+                { type: "label", x: 10, y: 40, width: 70, height: 12, text: "Bin" },
+                {
+                    type: "dropdown",
+                    x: 80,
+                    y: 35,
+                    width: 110,
+                    height: 12,
+                    items: binItems,
+                    selectedIndex: settings.selections.bin,
+                    onChange: function(index) { settings.bin = index; }
+                },
+                { type: "label", x: 10, y: 60, width: 70, height: 12, text: "Lamp" },
+                {
+                    type: "dropdown",
+                    x: 80,
+                    y: 55,
+                    width: 110,
+                    height: 12,
+                    items: lampItems,
+                    selectedIndex: settings.selections.lamp,
+                    onChange: function(index) { settings.lamp = index; }
+                },
+                { type: "label", x: 10, y: 80, width: 70, height: 12, text: "Queue TV" },
+                {
+                    type: "dropdown",
+                    x: 80,
+                    y: 75,
+                    width: 110,
+                    height: 12,
+                    items: tvItems,
+                    selectedIndex: settings.selections.queuetv,
+                    onChange: function(index) { settings.queuetv = index; }
+                }
+            ]
+        });
+    }
     var running = false;
     function runAdd() {
         if (running)
@@ -293,6 +358,8 @@ function main() {
     } else {
         Add(settings);
     }
+
+    ui.registerMenuItem("Better Benchwarmer", openMenu);
 }
 
 registerPlugin({


### PR DESCRIPTION
## Summary
- add UI menu to choose bench, bin, lamp and queue TV objects
- persist selections via `context.sharedStorage`
- document using the new menu

## Testing
- `node --check better_benchwarmer.js`

------
https://chatgpt.com/codex/tasks/task_e_684f5843ec9c8324ad8f320d0141cc8b